### PR TITLE
Close files explicitly when done

### DIFF
--- a/moonscript/init.lua
+++ b/moonscript/init.lua
@@ -49,6 +49,7 @@ moon_loader = function(name)
   end
   if file then
     local text = file:read("*a")
+    file:close()
     return loadstring(text, file_path)
   else
     return nil, "Could not find moon file"
@@ -82,6 +83,7 @@ loadfile = function(fname)
     return nil, err
   end
   local text = assert(file:read("*a"))
+  file:close()
   return loadstring(text, fname)
 end
 dofile = function(fname)

--- a/moonscript/init.moon
+++ b/moonscript/init.moon
@@ -50,6 +50,7 @@ moon_loader = (name) ->
 
   if file
     text = file\read "*a"
+    file\close!
     loadstring text, file_path
   else
     nil, "Could not find moon file"
@@ -74,6 +75,7 @@ loadfile = (fname) ->
   file, err = io.open fname
   return nil, err if not file
   text = assert file\read "*a"
+  file\close!
   loadstring text, fname
 
 -- throws errros


### PR DESCRIPTION
Makes sure files are closed right away in init.moon. From the commit message:

Even though files are automatically closed, per the manual
it takes "an unpredictable amount of time to happen".
