### PR TITLE
Add numeric for line decorators

### DIFF
--- a/moonscript/parse.lua
+++ b/moonscript/parse.lua
@@ -270,6 +270,10 @@ local function wrap_decorator(stm, dec)
 	elseif dec[1] == "comprehension" then
 		local _, clauses = unpack(dec)
 		stm = {"comprehension", stm, clauses}
+	elseif dec[1] == "for" then
+		local _, name, bounds = unpack(dec)
+		-- Not 100% on the bounds[x][2] part
+		stm = {"for", name, {bounds[1][2], bounds[2][2]}, {stm}}
 	end
 
 	return stm
@@ -367,6 +371,7 @@ local build_grammar = wrap_env(function()
 				-- statement decorators
 				key"if" * Exp * (key"else" * Exp)^-1 * Space / mark"if" +
 				key"unless" * Exp / mark"unless" +
+				key"for" * (Name * sym"=" * Ct(Exp * sym"," * Exp * (sym"," * Exp)^-1)) / mark"for" +
 				CompInner / mark"comprehension"
 			) * Space)^-1 / wrap_decorator,
 

--- a/tests/inputs/syntax.moon
+++ b/tests/inputs/syntax.moon
@@ -104,6 +104,8 @@ x = -[x for x in x]
 print "hello" if cool
 print "hello" unless cool
 print "hello" unless 1212 and 3434 -- hello
+print i for i in *x
+print i for i=1,10
 
 print "nutjob"
 

--- a/tests/outputs/syntax.lua
+++ b/tests/outputs/syntax.lua
@@ -107,6 +107,14 @@ end
 if not (1212 and 3434) then
   print("hello")
 end
+local _list_0 = x
+for _index_0 = 1, #_list_0 do
+  i = _list_0[_index_0]
+  print(i)
+end
+for i = 1, 10 do
+  print(i)
+end
 print("nutjob")
 if hello then
   _ = 343
@@ -150,9 +158,9 @@ y = y / 100
 local m = m % 2
 local hello = hello .. "world"
 x = 0
-local _list_0 = values
-for _index_0 = 1, #_list_0 do
-  local v = _list_0[_index_0]
+local _list_1 = values
+for _index_0 = 1, #_list_1 do
+  local v = _list_1[_index_0]
   _ = ((function()
     if ntype(v) == "fndef" then
       x = x + 1


### PR DESCRIPTION
This adds support for numeric for loop line decorators. I don't think this is quite right yet, so it may need to take a couple more commits (and then an interactive rebase) before it's actually ready to pull. That is, unless you want to just clean it up yourself.

**Issues**
I think what I added to Statement is correct:

``` lua
key"for" * (Name * sym"=" * Ct(Exp * sym"," * Exp * (sym"," * Exp)^-1)) / mark"for" +
```

but the part I'm unsure of is in wrap_decorator:

``` lua
stm = {"for", name, {bounds[1][2], bounds[2][2]}, {stm}}
```

I don't think the bounds[][2] is the right way to do this.

The other issue is that make test fails with the last line of the syntax.lua and I'm not entirely sure why.

--Edit--
One other thought which might be better brought up in a new issue: adding numeric for loops for list comprehensions. I'm not totally sure how useful they'd be in real world examples, but I could imagine something like this:

``` moonscript
v = [i*2 for i=1,10]
```

Other thoughts, adding when clause to numeric for loops so you could do something similar to this:

``` moonscript
v = [i*2 for i=1,10 when i%2==0] -- double evens
```
