### PR TITLE
Made spaces between callee and arguments mandatory

### DIFF
--- a/moonscript/parse.lua
+++ b/moonscript/parse.lua
@@ -597,7 +597,7 @@ local build_grammar = wrap_env(function()
 		ExpList = Exp * (sym"," * Exp)^0,
 		ExpListLow = Exp * ((sym"," + sym";") * Exp)^0,
 
-		InvokeArgs = ExpList * (sym"," * (TableBlock + SpaceBreak * Advance * ArgBlock * TableBlock^-1) + TableBlock)^-1 + TableBlock,
+		InvokeArgs = SomeSpace * ExpList * (sym"," * (TableBlock + SpaceBreak * Advance * ArgBlock * TableBlock^-1) + TableBlock)^-1 + TableBlock,
 		ArgBlock = ArgLine * (sym"," * SpaceBreak * ArgLine)^0 * PopIndent,
 		ArgLine = CheckIndent * ExpList
 	}

--- a/tests/inputs/lists.moon
+++ b/tests/inputs/lists.moon
@@ -1,5 +1,5 @@
 
-hi = [x*2 for _, x in ipairs{1,2,3,4}]
+hi = [x*2 for _, x in ipairs {1,2,3,4}]
 
 items = {1,2,3,4,5,6}
 
@@ -30,14 +30,14 @@ dump [{x, y} for x in range 5 when x > 2 for y in range 5]
 
 things = [x + y for x in range 10 when x > 5 for y in range 10 when y > 7]
 
-print x,y for x in ipairs{1,2,4} for y in ipairs{1,2,3} when x != 2
+print x,y for x in ipairs {1,2,4} for y in ipairs {1,2,3} when x != 2
 
 print "hello", x for x in items
 
 [x for x in x]
 x = [x for x in x]
 
-print x,y for x in ipairs{1,2,4} for y in ipairs{1,2,3} when x != 2
+print x,y for x in ipairs {1,2,4} for y in ipairs {1,2,3} when x != 2
 
 double = [x*2 for x in *items]
 


### PR DESCRIPTION
This patch simply makes it necessary to separate a callee and its arguments by a space.
Because the ambiguity in: 

```
a = 42
b = a-1
```

Is just ridiculous, not to mention non-obvious.
