### PR TITLE
Documentation fix: run_callback is defined, not called.

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1439,7 +1439,7 @@ my_object = {
   write: => print "the value:", @value
 }
 
-run_callback (func) ->
+run_callback = (func) ->
   print "running callback..."
   func!
 


### PR DESCRIPTION
At first I thought `run_callback` was a built-in function, but Lua's output says otherwise:

`lua: classes.lua:188: attempt to call global 'run_callback' (a nil value)`

This is a tiny documentation fix so people don't get confused. :smiley:
