### PR TITLE
added '-o file' option to control output name/destination

### DIFF
--- a/bin/moonc
+++ b/bin/moonc
@@ -9,7 +9,7 @@ local dump_tree = require"moonscript.dump".tree
 local alt_getopt = require "alt_getopt"
 local lfs = require "lfs"
 
-local opts, ind = alt_getopt.get_opts(arg, "lvhwt:pTXb", {
+local opts, ind = alt_getopt.get_opts(arg, "lvhwt:o:pTXb", {
 	print = "p", tree = "T", version = "v", help = "h", lint = "l"
 })
 
@@ -22,6 +22,7 @@ local help = [[Usage: %s [options] files...
     -h          Print this message
     -w          Watch file/directory
     -t path     Specify where to place compiled files
+    -o file     Write output to file
     -p          Write output to standard out
     -T          Write parse tree instead of code (to stdout)
     -X          Write line rewrite map instead of code (to stdout)
@@ -372,7 +373,12 @@ if opts.w then
 	end
 
 	for fname in protected do
-		local target = target_dir..convert_path(fname)
+		local target 
+		if opts.o then
+		  target = opts.o
+		else
+  		target = target_dir..convert_path(fname)
+  	end
 		local success, err = compile_and_write(fname, target)
 		if not success then
 			io.stderr:write(table.concat({
@@ -399,7 +405,13 @@ elseif opts.l then
 	end
 else
 	for _, fname in ipairs(files) do
-		local success, err = compile_and_write(fname, target_dir..convert_path(fname))
+	  local target
+	  if opts.o then
+      target = opts.o
+    else
+      target = target_dir..convert_path(fname)
+    end
+		local success, err = compile_and_write(fname, target)
 		if not success then
 			io.stderr:write(fname .. "\t" .. err .. "\n")
 			os.exit(1)


### PR DESCRIPTION
I was having trouble using `moonc -t path files...` to control where to put the compiled Lua files in one of my projects' Makefiles. This PR adds functionality similar to gcc's `-o file` to `moonc` and should be a workaround for leafo/moonscript#137

I [wrote some behavioral tests](https://github.com/cahna/moonscript/blob/moonc-behavior-tests/spec/moonc_usage_spec.moon), too, in order to verify the new feature and some existing ones, but haven't had the time to cover all use cases or fix leafo/moonscript#137 yet. I can PR the tests, but I'm not sure how you'd feel about the [CLI-like usage hack](https://github.com/cahna/moonscript/blob/moonc-behavior-tests/spec/moonc_usage_spec.moon#L32) it includes. It seems elegant enough, and would be better than adding something like a [bats](https://github.com/sstephenson/bats) dependency just for some over-zealous testing.
