### PR TITLE
Version module fix

### DIFF
--- a/moonscript/version.lua
+++ b/moonscript/version.lua
@@ -1,5 +1,5 @@
 
-version = "0.2.5"
+local version = "0.2.5"
 
 return {
   version = version,


### PR DESCRIPTION
`moonscript.version` still used `module()`. I'm not sure if this is preserving any kind of backwards compatibility, but updating this to return a table didn't break any tests that I observed :punch: 
