### PR TITLE
Fix for moonc -w

### DIFF
--- a/bin/moonc
+++ b/bin/moonc
@@ -165,7 +165,7 @@ end
 local function get_sleep_func()
 	local sleep
 	if not pcall(function()
-		require "socket"
+		local socket = require "socket"
 		sleep = socket.sleep
 	end) then
 		-- This is set by moonc.c in windows binaries


### PR DESCRIPTION
I get this traceback when I try to run `moonc -w`:

```
/usr/bin/lua5.2: /usr/local/lib/luarocks/rocks/moonscript/dev-1/bin/moonc:175: Missing sleep function; install LuaSocket
stack traceback:
    [C]: in function 'error'
    /usr/local/lib/luarocks/rocks/moonscript/dev-1/bin/moonc:175: in function 'get_sleep_func'
    /usr/local/lib/luarocks/rocks/moonscript/dev-1/bin/moonc:240: in function 'create_watcher'
    /usr/local/lib/luarocks/rocks/moonscript/dev-1/bin/moonc:267: in main chunk
    [C]: in ?
```

This tiny change fixes it. :smiley: 
