### PR TITLE
Fix package.moonpath generation

### DIFF
--- a/moonscript/base.lua
+++ b/moonscript/base.lua
@@ -18,14 +18,16 @@ local dirsep, line_tables, create_moonpath, to_lua, moon_loader, loadstring, loa
 dirsep = "/"
 line_tables = require("moonscript.line_tables")
 create_moonpath = function(package_path)
-  local paths = split(package_path, ";")
-  for i, path in ipairs(paths) do
+  local moonpaths = { }
+  local _list_0 = split(package.path, ";")
+  for _index_0 = 1, #_list_0 do
+    local path = _list_0[_index_0]
     local p = path:match("^(.-)%.lua$")
     if p then
-      paths[i] = p .. ".moon"
+      insert(moonpaths, p .. ".moon")
     end
   end
-  return concat(paths, ";")
+  return concat(moonpaths, ";")
 end
 to_lua = function(text, options)
   if options == nil then

--- a/moonscript/base.moon
+++ b/moonscript/base.moon
@@ -13,11 +13,11 @@ line_tables = require "moonscript.line_tables"
 
 -- create moon path package from lua package path
 create_moonpath = (package_path) ->
-  paths = split package_path, ";"
-  for i, path in ipairs paths
+  moonpaths = {}
+  for path in *split package.path, ";"
     p = path\match "^(.-)%.lua$"
-    if p then paths[i] = p..".moon"
-  concat paths, ";"
+    if p then insert moonpaths, p..".moon"
+  concat moonpaths, ";"
 
 to_lua = (text, options={}) ->
   if "string" != type text


### PR DESCRIPTION
When building `package.moonpath` from `package.path`, currently paths not ending in `.lua` are simply copied in it. So, if there is such a path in `package.path` (e.g. `./?.luac` for loading precompiled bytecode), moonscript loader will try it (and fail). The patch fixes `create_moonpath` function to ignore paths in `package.path` not ending in `.lua`.