### PR TITLE
Fixed moonc '-b' option

### DIFF
--- a/moonscript/cmd/moonc.moon
+++ b/moonscript/cmd/moonc.moon
@@ -105,7 +105,7 @@ compile_file_text = (text, opts={}) ->
       "Compile time\t" .. format_time(compile_time),
       ""
     }, "\n"
-    return nil
+	return true
 
   code
 


### PR DESCRIPTION
MoonScript v0.3.1's `moonc -b`  has been broken. 

```
moonc -b test.moon
test.moon
Parse time      7.126ms
Compile time    1.626ms

/usr/bin/lua: ...ocks/lib/luarocks/rocks-5.3/moonscript/0.3.2-1/bin/moonc:326: attempt to concatenate a nil value (local 'err')
stack traceback:
        ...ocks/lib/luarocks/rocks-5.3/moonscript/0.3.2-1/bin/moonc:326: in main chunk
        [C]: in ?
```