### PR TITLE
Fix issue with nested `with` loops

### DIFF
--- a/moonscript/transform.lua
+++ b/moonscript/transform.lua
@@ -713,11 +713,11 @@ Statement = Transformer({
     end
     scope_name = scope_name or NameProxy("with")
     return build["do"]({
+      copy_scope and build.assign_one(scope_name, exp) or NOOP,
+      named_assign or NOOP,
       Run(function(self)
         return self:set("scope_var", scope_name)
       end),
-      copy_scope and build.assign_one(scope_name, exp) or NOOP,
-      named_assign or NOOP,
       build.group(block),
       (function()
         if ret then

--- a/moonscript/transform.moon
+++ b/moonscript/transform.moon
@@ -418,9 +418,9 @@ Statement = Transformer {
     scope_name or= NameProxy "with"
 
     build.do {
-      Run => @set "scope_var", scope_name
       copy_scope and build.assign_one(scope_name, exp) or NOOP
       named_assign or NOOP
+      Run => @set "scope_var", scope_name
       build.group block
 
       if ret

--- a/spec/inputs/with.moon
+++ b/spec/inputs/with.moon
@@ -93,6 +93,16 @@ do
   with k.j = "jo"
     print \upper!
 
+do
+  with a
+    print .b
+    -- nested `with`s should change the scope correctly
+    with .c
+      print .d
 
-
+do
+  with a
+    -- nested `with`s with assignments should change the scope correctly
+    with .b = 2
+      print .c
 

--- a/spec/outputs/with.lua
+++ b/spec/outputs/with.lua
@@ -131,6 +131,26 @@ do
     local _with_0 = "jo"
     k.j = _with_0
     print(_with_0:upper())
+  end
+end
+do
+  do
+    local _with_0 = a
+    print(_with_0.b)
+    do
+      local _with_1 = _with_0.c
+      print(_with_1.d)
+    end
+  end
+end
+do
+  do
+    local _with_0 = a
+    do
+      local _with_1 = 2
+      _with_0.b = _with_1
+      print(_with_1.c)
+    end
     return _with_0
   end
 end


### PR DESCRIPTION
When compiling code such as the following:
```
with a
  with .b
    print .c
```
The correct output should be roughly equivalent to `print a.b.c`. However, this is not the case, and moonc bombs with an error when code like this is run, even in the presence of a suitable table structure (so that `a.b.c` is defined).
This is because moonc currently compiles the above snippet into this (note the `_with_1.b` part):
```
do
  local _with_0 = a
  do 
    local _with_1 = _with_1.b
    print _with_1.c
  end
end
```
This happens because when the transformer emits the `_with_1` assignment, `scope_var` (which is used by values to look up the current scope when the short-dot syntax is used) has already been set to the new one (from the nested block). This fix simply reorders the `scope_var` assignment so that it happens *after* these statements have been emitted, so the correct scope is being used.
This PR fixes #187 (and #197, its dupe).