### PR TITLE
Added merge in the standard library

### DIFF
--- a/moon/init.moon
+++ b/moon/init.moon
@@ -98,6 +98,12 @@ extend = (...) ->
 copy = =>
   {key,val for key,val in pairs self}
 
+-- merges the content of the second table with the content in the second table
+merge = (tbl) =>
+  for k, v in pairs tbl
+    self[k] = v
+  self
+
 -- mixin class properties into self, call new
 mixin = (cls, ...) =>
   for key, val in pairs cls.__base


### PR DESCRIPTION
The merge function takes 2 tables as arguments and merges them and returns the first table.
Merging 2 tables is common as the copy function