### PR TITLE
resolve LUA_PATH overwrite problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 LUA ?= lua5.1
 LUA_VERSION = $(shell $(LUA) -e 'print(_VERSION:match("%d%.%d"))')
 LUAROCKS = luarocks-$(LUA_VERSION)
-LUA_PATH_MAKE = $(shell $(LUAROCKS) path --lr-path)
-LUA_CPATH_MAKE = $(shell $(LUAROCKS) path --lr-cpath)
+LUA_PATH_MAKE = $(shell $(LUAROCKS) path --lr-path);./?.lua;./?/init.lua
+LUA_CPATH_MAKE = $(shell $(LUAROCKS) path --lr-cpath);./?.so
 
 .PHONY: test local compile compile_system watch lint count show
 


### PR DESCRIPTION
`LUA_PATH_MAKE` in Makefile overwrites `LUA_PATH` and the overwritten doesn't contain `./?.lua`.
In the environment that isn't installed MoonScript, Building the moon from the source fails due to the lack of the path.