### PR TITLE
bin/moonc: fixes #259 when not using inotify

### DIFF
--- a/bin/moonc
+++ b/bin/moonc
@@ -247,8 +247,10 @@ local function create_watcher(files)
 				for _, tuple in ipairs(files) do
 					local file = tuple[1]
 					local time = lfs.attributes(file, "modification")
-					if not mod_time[file] then
-						mod_time[file] = time
+					if not time then
+						mod_time[file] = nil -- file doesn't exist
+					elseif not mod_time[file] then
+						mod_time[file] = time -- new file created
 					else
 						if time ~= mod_time[file] then
 							if time > mod_time[file] then


### PR DESCRIPTION
Old files were still tracked. Now, if you can't get the `stat()` information, they're dropped.