### PR TITLE
moonscript/cmd/args.moon: fix unpack for 5.2+

### DIFF
--- a/moonscript/cmd/args.lua
+++ b/moonscript/cmd/args.lua
@@ -1,3 +1,5 @@
+local unpack
+unpack = require("moonscript.util").unpack
 local parse_spec
 parse_spec = function(spec)
   local flags, words

--- a/moonscript/cmd/args.moon
+++ b/moonscript/cmd/args.moon
@@ -1,4 +1,4 @@
-
+import unpack from require "moonscript.util"
 parse_spec = (spec) ->
   flags, words = if type(spec) == "table"
     unpack(spec), spec


### PR DESCRIPTION
Lua 5.2+ have changed the global `unpack` function to `table.unpack`; this offers a fix.