### PR TITLE
busted version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - source .travis/setenv_lua.sh
 
 install:
-  - luarocks install https://luarocks.org/manifests/olivine-labs/busted-2.0.rc11-0.rockspec
+  - luarocks install https://luarocks.org/manifests/olivine-labs/busted-2.0.rc12-1.rockspec
   - luarocks install loadkit
   - luarocks make
 


### PR DESCRIPTION
Now, Travis CI returns an error. This can be avoided by updating busted.

```
/home/travis/build/leafo/moonscript/install/lua/bin/lua: ...pt/install/luarocks/share/lua/5.3/busted/modules/cli.lua:111: attempt to call a nil value (method 'add_flag')
stack traceback:
	...pt/install/luarocks/share/lua/5.3/busted/modules/cli.lua:111: in function 'busted.modules.cli'
	...nscript/install/luarocks/share/lua/5.3/busted/runner.lua:18: in function 'busted.runner'
	...luarocks/lib/luarocks/rocks/busted/2.0.rc11-0/bin/busted:3: in main chunk
	[C]: in ?
```