### PR TITLE
Busted + penlight v1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LUA_CPATH_MAKE = $(shell $(LUAROCKS) path --lr-cpath);./?.so
 .PHONY: test local compile compile_system watch lint count show
 
 test:
-	busted
+	busted spec/*_spec.moon
 
 show:
 	# LUA $(LUA)


### PR DESCRIPTION
Busted + penlight v1.4 can't find the spec file, so you must specify the spec files