### PR TITLE
switched the alt_getopt module import to work with newer versions of lua

### DIFF
--- a/bin/moon
+++ b/bin/moon
@@ -1,5 +1,5 @@
 #!/usr/bin/env lua
-require("alt_getopt")
+local alt_getopt = require("alt_getopt")
 local moonscript = require("moonscript.base")
 local util = require("moonscript.util")
 local errors = require("moonscript.errors")

--- a/bin/moon.moon
+++ b/bin/moon.moon
@@ -1,5 +1,5 @@
 
-require "alt_getopt"
+alt_getopt = require "alt_getopt"
 
 moonscript = require "moonscript.base"
 util = require "moonscript.util"

--- a/bin/splat.moon
+++ b/bin/splat.moon
@@ -2,8 +2,8 @@
 
 -- concatenate a collection of lua modules into one
 
-require "lfs"
-require "alt_getopt"
+lfs = require "lfs"
+alt_getopt = require "alt_getopt"
 
 import insert, concat from table
 import dump, split from require "moonscript.util"


### PR DESCRIPTION
This is a fix for issue #253 that allows one to just use the version of Lua that comes with one's Linux distribution.

I know the plan is to get rid of getopt, but in the mean time this will allow people to use Moonscript without jumping through a lot of hoops.