### PR TITLE
Specify that directories are also accepted

### DIFF
--- a/bin/moonc
+++ b/bin/moonc
@@ -9,7 +9,7 @@ local opts, ind = alt_getopt.get_opts(arg, "lvhwt:o:pTXb", {
 
 local read_stdin = arg[1] == "--"
 
-local help = [[Usage: %s [options] files...
+local help = [[Usage: %s [options] files/directories...
 
     -h          Print this message
     -w          Watch file/directory


### PR DESCRIPTION
Fixes #293.

Small change in wording to make it a bit clearer that you can provide directory names to moonc, not just file names.