### PR TITLE
Fix to allow debug.upvalue() to set upvalues to nil

### DIFF
--- a/moon/init.lua
+++ b/moon/init.lua
@@ -25,25 +25,24 @@ type = function(value)
   return base_type
 end
 debug = setmetatable({
-  upvalue = function(fn, k, v)
-    local upvalues = { }
+  upvalue = function(fn, k, ...)
+    local value = nil
     local i = 1
     while true do
-      local name = lua.debug.getupvalue(fn, i)
+      local name
+      name, value = lua.debug.getupvalue(fn, i)
       if name == nil then
+        error("Failed to find upvalue: " .. tostring(k))
+      end
+      if name == k then
         break
       end
-      upvalues[name] = i
       i = i + 1
     end
-    if not upvalues[k] then
-      error("Failed to find upvalue: " .. tostring(k))
-    end
-    if not v then
-      local _, value = lua.debug.getupvalue(fn, upvalues[k])
+    if select("#", ...) == 0 then
       return value
     else
-      return lua.debug.setupvalue(fn, upvalues[k], v)
+      return lua.debug.setupvalue(fn, i, ...)
     end
   end
 }, {

--- a/moon/init.moon
+++ b/moon/init.moon
@@ -18,23 +18,20 @@ type = (value) -> -- class aware type
   base_type
 
 debug = setmetatable {
-  upvalue: (fn, k, v) ->
-    upvalues = {}
+  upvalue: (fn, k, ...) ->
+    value = nil
     i = 1
     while true
-      name = lua.debug.getupvalue(fn, i)
-      break if name == nil
-      upvalues[name] = i
+      name, value = lua.debug.getupvalue(fn, i)
+      if name == nil
+        error "Failed to find upvalue: " .. tostring k
+      break if name == k
       i += 1
 
-    if not upvalues[k]
-      error "Failed to find upvalue: " .. tostring k
-
-    if not v
-      _, value = lua.debug.getupvalue fn, upvalues[k]
+    if select("#", ...) == 0
       value
     else
-      lua.debug.setupvalue fn, upvalues[k], v
+      lua.debug.setupvalue fn, i, ...
 }, __index: lua.debug
 
 -- run a function with scope injected before its function environment


### PR DESCRIPTION
This should make it faster (it now stops scanning when it hits the desired upvalue) and more correct. It now allows setting an upvalue to a falsey or nil value, e.g. debug.upvalue(fn, 'foo', nil) (set 'foo' to nil), which is treated differently different from debug.upvalue(fn, 'foo') (get the value of 'foo').