### PR TITLE
Issue #376, Table's element identifier followed (glued) by a colon ':'

### DIFF
--- a/moonscript/parse.lua
+++ b/moonscript/parse.lua
@@ -184,7 +184,7 @@ local build_grammar = wrap_env(debug_grammar, function(root)
     ClassBlock = SpaceBreak ^ 1 * Advance * Ct(ClassLine * (SpaceBreak ^ 1 * ClassLine) ^ 0) * PopIndent,
     ClassLine = CheckIndent * ((KeyValueList / mark("props") + Statement / mark("stm") + Exp / mark("stm")) * sym(",") ^ -1),
     Export = key("export") * (Cc("class") * ClassDecl + op("*") + op("^") + Ct(NameList) * (sym("=") * Ct(ExpListLow)) ^ -1) / mark("export"),
-    KeyValue = (sym(":") * -SomeSpace * Name * lpeg.Cp()) / self_assign + Ct((KeyName + sym("[") * Exp * sym("]") + Space * DoubleString + Space * SingleString) * symx(":") * (Exp + TableBlock + SpaceBreak ^ 1 * Exp)),
+    KeyValue = (sym(":") * -SomeSpace * Name * lpeg.Cp()) / self_assign + Ct((KeyName + sym("[") * Exp * sym("]") + Space * DoubleString + Space * SingleString) * Space * symx(":") * (Exp + TableBlock + SpaceBreak ^ 1 * Exp)),
     KeyValueList = KeyValue * (sym(",") * KeyValue) ^ 0,
     KeyValueLine = CheckIndent * KeyValueList * sym(",") ^ -1,
     FnArgsDef = sym("(") * White * Ct(FnArgDefList ^ -1) * (key("using") * Ct(NameList + Space * "nil") + Ct("")) * White * sym(")") + Ct("") * Ct(""),

--- a/moonscript/parse.moon
+++ b/moonscript/parse.moon
@@ -285,7 +285,7 @@ build_grammar = wrap_env debug_grammar, (root) ->
     KeyValue: (sym":" * -SomeSpace *  Name * lpeg.Cp!) / self_assign +
       Ct(
         (KeyName + sym"[" * Exp * sym"]" +Space * DoubleString + Space * SingleString) *
-        symx":" *
+        Space * symx":" *
         (Exp + TableBlock + SpaceBreak^1 * Exp)
       )
 

--- a/spec/destructure_spec.moon
+++ b/spec/destructure_spec.moon
@@ -30,3 +30,31 @@ describe "destructure", ->
     assert.same street, "Via Roma 42R"
     assert.same city, "Bellagio, Italy 22021"
 
+  it "should destructure with colon ':' separated from table's element identifier", ->
+    -- Create a table with the colon ':' separated
+    -- from some of the element identifiers of the table
+    futurists =
+      sculptor: "Umberto Boccioni"
+      painter : "Vladimir Burliuk"
+      poet    : {
+        name   : "F.T. Marinetti"
+        address: { "Via Roma 42R", "Bellagio, Italy 22021"}
+      }
+
+    -- And destructure the 'futurists' table
+    -- with some element identifiers separated from the colon ':'
+    {
+      sculptor: sculptorName,
+      painter : painterName,
+      poet    : {
+        name   : poetName,
+        address: { poetStreet, poetCity }
+      }
+    } = futurists
+
+    assert.same sculptorName, "Umberto Boccioni"
+    assert.same painterName, "Vladimir Burliuk"
+    assert.same poetName, "F.T. Marinetti"
+    assert.same poetStreet, "Via Roma 42R"
+    assert.same poetCity, "Bellagio, Italy 22021"
+


### PR DESCRIPTION
I did the changes needed for the issue #376 and created a test spec to test it.