### PR TITLE
"-t --output-to" should be an option not a flag

### DIFF
--- a/bin/moonc
+++ b/bin/moonc
@@ -10,7 +10,7 @@ parser:flag("-v --version", "Print version")
 parser:flag("-w --watch", "Watch file/directory for updates")
 parser:option("--transform", "Transform syntax tree with module")
 parser:mutex(
-	parser:flag("-t --output-to", "Specify where to place compiled files"),
+	parser:option("-t --output-to", "Specify where to place compiled files"),
 	parser:option("-o", "Write output to file"),
 	parser:flag("-p", "Write output to standard output"),
 	parser:flag("-T", "Write parse tree instead of code (to stdout)"),


### PR DESCRIPTION
When -t is set as a flag it will fail due to unexpected boolean in the code
`moonscript\cmd\moonc.lua:22`