### PR TITLE
Fix `-` flag for `moonc`

### DIFF
--- a/bin/moonc
+++ b/bin/moonc
@@ -24,6 +24,11 @@ local read_stdin = arg[1] == "-" -- luacheck: ignore 113
 
 if not read_stdin then
 	parser:argument("file/directory"):args("+")
+else
+	if arg[2] ~= nil then
+		io.stderr:write("- must be the only argument\n")
+		os.exit(1)
+	end
 end
 
 local opts = read_stdin and {} or parser:parse()

--- a/bin/moonc
+++ b/bin/moonc
@@ -20,7 +20,7 @@ parser:mutex(
 parser:flag("-",
 	"Read from standard in, print to standard out (Must be only argument)")
 
-local read_stdin = arg[1] == "--" -- luacheck: ignore 113
+local read_stdin = arg[1] == "-" -- luacheck: ignore 113
 
 if not read_stdin then
 	parser:argument("file/directory"):args("+")

--- a/bin/moonc
+++ b/bin/moonc
@@ -26,7 +26,7 @@ if not read_stdin then
 	parser:argument("file/directory"):args("+")
 end
 
-local opts = parser:parse()
+local opts = read_stdin and {} or parser:parse()
 
 if opts.version then
 	local v = require "moonscript.version"


### PR DESCRIPTION
`moonc` currently tells argparse to expect `-`, but actually checks for `--` on the cli, which breaks `moonc -`; this PR fixes this and forces `-` to be the only argument (like `-h` tells us) (fixes #431)