### PR TITLE
Fix #461: printing version doesn't work with args

### DIFF
--- a/bin/moonc
+++ b/bin/moonc
@@ -26,7 +26,7 @@ parser:flag("-",
 local read_stdin = arg[1] == "-" -- luacheck: ignore 113
 
 if not read_stdin then
-  parser:argument("file/directory"):args("+")
+  parser:argument("file/directory"):args("*")
 else
   if arg[2] ~= nil then
     io.stderr:write("- must be the only argument\n")
@@ -39,6 +39,11 @@ local opts = read_stdin and {} or parser:parse()
 if opts.version then
   local v = require "moonscript.version"
   v.print_version()
+  os.exit()
+end
+
+if not read_stdin and #opts["file/directory"] == 0 then
+  io.stderr:write(parser:get_help())
   os.exit()
 end
 


### PR DESCRIPTION
Fix #461 

No args will print help:

```
qaisjp@qaispc:~/moonscript$ lua bin/moonc
Usage: bin/moonc
       ([-t <output_to>] | [-o <o>] | [-p] | [-T] | [-b] | [-X]) [-h]
       [-l] [-v] [-w] [--transform <transform>] [-]
       [<file/directory>] ...

Arguments:
   file/directory

Options:
   -h, --help            Show this help message and exit.
   -l, --lint            Perform a lint on the file instead of compiling
   -v, --version         Print version
   -w, --watch           Watch file/directory for updates
   --transform <transform>
                         Transform syntax tree with module
            -t <output_to>,
   --output-to <output_to>
                         Specify where to place compiled files
```


Version works normally:

```
qaisjp@qaispc:~/moonscript$ lua bin/moonc  -v
MoonScript version 0.5.0
```

Version with path works too:

```
qaisjp@qaispc:~/moonscript$ lua bin/moonc -v hi
MoonScript version 0.5.0
qaisjp@qaispc:~/moonscript$ lua bin/moonc hi -v
MoonScript version 0.5.0
```

Works fine with file too
```
qaisjp@qaispc:~/moonscript$ lua bin/moonc foo.moon
foo.moon        Can't find file
```
