### PR TITLE
WIP: Fix incompatibilities with Lua 5.5

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,6 +1,6 @@
 name: "spec"
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: ["5.1", "5.2", "5.3", "5.4", "5.5", "luajit", "luajit-openresty"]
+        luaVersion: ["5.1", "5.2", "5.3", "5.4", "5.5.0", "luajit", "luajit-openresty"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: ["5.1", "5.2", "5.3", "5.4", "luajit", "luajit-openresty"]
+        luaVersion: ["5.1", "5.2", "5.3", "5.4", "5.5", "luajit", "luajit-openresty"]
 
     runs-on: ubuntu-latest
 
@@ -19,6 +19,8 @@ jobs:
         luaVersion: ${{ matrix.luaVersion }}
 
     - uses: leafo/gh-actions-luarocks@master
+      with:
+        luarocksVersion: "3.13.0"
 
     - name: build
       run: |

--- a/moon/init.lua
+++ b/moon/init.lua
@@ -7,7 +7,7 @@ do
   local _obj_0 = require("moonscript.util")
   getfenv, setfenv, dump = _obj_0.getfenv, _obj_0.setfenv, _obj_0.dump
 end
-local p, is_object, type, debug, run_with_scope, bind_methods, defaultbl, extend, copy, mixin, mixin_object, mixin_table, fold
+local p, is_object, type, debug, run_with_scope, bind_methods, defaultbl, extend, copy, mixin, mixin_object, mixin_table, fold, len
 p = function(o, ...)
   print(dump(o))
   if select("#", ...) > 0 then
@@ -149,7 +149,7 @@ mixin_table = function(self, tbl, keys)
   end
 end
 fold = function(items, fn)
-  local len = #items
+  len = #items
   if len > 1 then
     local accum = fn(items[1], items[2])
     for i = 3, len do
@@ -159,6 +159,15 @@ fold = function(items, fn)
   else
     return items[1]
   end
+end
+len = function(tbl)
+  local largest = 0
+  for key, val in pairs(tbl) do
+    if type(key) == "number" and key > largest then
+      largest = key
+    end
+  end
+  return largest
 end
 return {
   dump = dump,
@@ -174,5 +183,6 @@ return {
   mixin = mixin,
   mixin_object = mixin_object,
   mixin_table = mixin_table,
-  fold = fold
+  fold = fold,
+  len = len
 }

--- a/moon/init.moon
+++ b/moon/init.moon
@@ -129,7 +129,16 @@ fold = (items, fn)->
   else
     items[1]
 
+-- gets largest integer key of tbl
+len = (tbl)->
+  largest = 0
+  for key, val in pairs tbl
+    if type(key) == "number" and key > largest
+      largest = key
+  largest
+
 {
   :dump, :p, :is_object, :type, :debug, :run_with_scope, :bind_methods,
-  :defaultbl, :extend, :copy, :mixin, :mixin_object, :mixin_table, :fold
+  :defaultbl, :extend, :copy, :mixin, :mixin_object, :mixin_table, :fold,
+  :len
 }

--- a/moonscript-dev-1.rockspec
+++ b/moonscript-dev-1.rockspec
@@ -16,7 +16,7 @@ description = {
 dependencies = {
 	"lua >= 5.1",
 	"lpeg >= 0.10, ~= 0.11",
-	"argparse >= 0.7",
+--	"argparse >= 0.7",
 	"luafilesystem >= 1.5"
 }
 

--- a/moonscript/transform/class.lua
+++ b/moonscript/transform/class.lua
@@ -106,7 +106,7 @@ super_scope = function(value, t, key)
   }
 end
 return function(self, node, ret, parent_assign)
-  local name, parent_val, body = unpack(node, 2)
+  local name, parent_val, body = unpack(node, 2, 4)
   if parent_val == "" then
     parent_val = nil
   end

--- a/moonscript/transform/class.moon
+++ b/moonscript/transform/class.moon
@@ -76,7 +76,7 @@ super_scope = (value, t, key) ->
   }
 
 (node, ret, parent_assign) =>
-  name, parent_val, body = unpack node, 2
+  name, parent_val, body = unpack node, 2, 4
   parent_val = nil if parent_val == ""
 
   parent_cls_name = NameProxy "parent"

--- a/spec/moon_spec.moon
+++ b/spec/moon_spec.moon
@@ -15,7 +15,9 @@ describe "moon", ->
       Test, Test!, 1, true, nil, "hello"
     }
 
-    types = [moon.type t for t in *things]
+    types = {}
+    for i=1, moon.len things
+      types[i] = moon.type things[i]
     assert.same types, { Test, Test, "number", "boolean", "nil", "string" }
 
   it "should get upvalue", ->


### PR DESCRIPTION
Basically, in a few places moonscript will do:

```
tbl = {"foo", nil, "bar", "baz"}
```

And expect `#tbl` to be `4`. While this was never guaranteed behavior in Lua (the reference manual states that *any* table border can be returned in this case), under PUC-Rio Lua <5.5 (and LuaJIT, which presumably emulates the behavior of PUC-Rio Lua 5.1), it would work correctly. However, with the update to 5.5, this has now broken. As a result, some things that worked under previous versions no longer do.

I've made changes in 3 places to fix this:

- Added `moon.len`, a function which returns the largest integer key in a table
- Fixed the `unpack` call in `moonscript.transform.class` to unpack indices 2 to 4, instead of leaving the last index as `#node`
- Fixed the `moon.type` test in `spec.moon_spec` to use `moon.len`.

I've also added `5.5.0` to the `spec` matrix and set luarocks to use 3.13.0, which supports Lua 5.5.